### PR TITLE
Add hardware support for NSK balance bot expansion board

### DIFF
--- a/dts/allwinner/sun8i-t113s-nerves-starter-kit.dts
+++ b/dts/allwinner/sun8i-t113s-nerves-starter-kit.dts
@@ -164,6 +164,41 @@
 		pins = "PD1", "PD2";
 		function = "uart2";
 	};
+
+	/*
+	 * The Beam Bots add-on board reaches the SoC entirely through the
+	 * 14 pin GPIO header, which carries PE2, PE3, PE5, PE8, PE9, PE10
+	 * and PE13.
+	 */
+	i2c0_pe_pins: i2c0-pe-pins {
+		pins = "PE2", "PE3";
+		function = "i2c0";
+	};
+
+	ledc_pe_pins: ledc-pe-pins {
+		pins = "PE5";
+		function = "ledc";
+	};
+
+	pwm2_pe_pin: pwm2-pe-pin {
+		pins = "PE8";
+		function = "pwm2";
+	};
+
+	pwm3_pe_pin: pwm3-pe-pin {
+		pins = "PE9";
+		function = "pwm3";
+	};
+
+	pwm4_pe_pin: pwm4-pe-pin {
+		pins = "PE10";
+		function = "pwm4";
+	};
+
+	pwm5_pe_pin: pwm5-pe-pin {
+		pins = "PE13";
+		function = "pwm5";
+	};
 };
 
 /* shell */
@@ -240,8 +275,67 @@
 	status = "okay";
 };
 
+/* Motor drivers on the add-on board. */
 &pwm {
-    status = "disabled";
+	pinctrl-names = "default";
+	pinctrl-0 = <&pwm2_pe_pin>, <&pwm3_pe_pin>, <&pwm4_pe_pin>, <&pwm5_pe_pin>;
+	status = "okay";
+};
+
+/*
+ * NeoPixels on the add-on board.
+ *
+ * 6.18 carries the LEDC driver and its clock and reset constants, but not the
+ * device tree node — that landed upstream afterwards. Declaring it here rather
+ * than patching the kernel keeps a device tree change to a device tree
+ * rebuild. Drop this in favour of the label once the kernel has caught up.
+ */
+&{/soc} {
+	ledc: led-controller@2008000 {
+		compatible = "allwinner,sun20i-d1-ledc",
+			     "allwinner,sun50i-a100-ledc";
+		reg = <0x2008000 0x400>;
+		interrupts = <SOC_PERIPHERAL_IRQ(20) IRQ_TYPE_LEVEL_HIGH>;
+		clocks = <&ccu CLK_BUS_LEDC>, <&ccu CLK_LEDC>;
+		clock-names = "bus", "mod";
+		resets = <&ccu RST_BUS_LEDC>;
+		dmas = <&dma 42>;
+		dma-names = "tx";
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		pinctrl-names = "default";
+		pinctrl-0 = <&ledc_pe_pins>;
+		status = "okay";
+
+		multi-led@0 {
+			reg = <0x0>;
+			color = <LED_COLOR_ID_RGB>;
+			function = LED_FUNCTION_INDICATOR;
+			function-enumerator = <0>;
+		};
+
+		multi-led@1 {
+			reg = <0x1>;
+			color = <LED_COLOR_ID_RGB>;
+			function = LED_FUNCTION_INDICATOR;
+			function-enumerator = <1>;
+		};
+
+		multi-led@2 {
+			reg = <0x2>;
+			color = <LED_COLOR_ID_RGB>;
+			function = LED_FUNCTION_INDICATOR;
+			function-enumerator = <2>;
+		};
+
+		multi-led@3 {
+			reg = <0x3>;
+			color = <LED_COLOR_ID_RGB>;
+			function = LED_FUNCTION_INDICATOR;
+			function-enumerator = <3>;
+		};
+	};
 };
 
 &uart0 {
@@ -256,9 +350,16 @@
 	status = "okay";
 };
 
+/*
+ * The onboard sensors sit on PB2/PB3 and the add-on board's IMU on PE2/PE3.
+ * Both pin pairs only offer i2c0, so the controller is muxed onto both and the
+ * two halves become one bus. They are open drain and every device has its own
+ * address, so they coexist; the cost is the extra bus capacitance and a second
+ * pair of pull-ups.
+ */
 &i2c0 {
 	pinctrl-names = "default";
-	pinctrl-0 = <&i2c0_pb_pins>;
+	pinctrl-0 = <&i2c0_pb_pins>, <&i2c0_pe_pins>;
 	status = "okay";
 };
 

--- a/dts/allwinner/sun8i-t113s-nsk-balance-bot.dts
+++ b/dts/allwinner/sun8i-t113s-nsk-balance-bot.dts
@@ -1,0 +1,363 @@
+// SPDX-License-Identifier: (GPL-2.0-or-later OR MIT)
+// Copyright (C) 2022 Arm Ltd.
+// Copyright (C) 2024 Connor Rigby <connorr@hey.com>
+
+#include <dt-bindings/interrupt-controller/irq.h>
+
+/dts-v1/;
+
+#include <arm/allwinner/sun8i-t113s.dtsi>
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+#include <dt-bindings/pwm/pwm.h>
+
+/ {
+	model = "Nerves Starter Kit Balance Bot";
+	compatible = "protolux,nerves-starter-kit", "allwinner,sun8i-t113s", "allwinner,sun8i";
+
+	aliases {
+		serial0 = &uart0;
+		serial2 = &uart2;
+		serial4 = &uart4;
+	};
+
+	chosen {
+		stdout-path = "serial4:115200n8";
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led-1 {
+			color = <LED_COLOR_ID_RED>;
+			function = LED_FUNCTION_STATUS;
+			gpios = <&pio 3 4 GPIO_ACTIVE_HIGH>; /* PD4 */
+			linux,default-trigger = "heartbeat";
+		};
+	};
+
+	poweroff {
+		compatible = "gpio-poweroff";
+		gpios = <&pio 4 1 GPIO_ACTIVE_HIGH>; /* PE1 */
+	};
+
+	reg_vcc5v: regulator-5v {
+		compatible = "regulator-fixed";
+		regulator-name = "vcc-5v";
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+		regulator-always-on;
+	};
+
+	reg_3v3: regulator-3v3 {
+		compatible = "regulator-fixed";
+		regulator-name = "vcc-3v3";
+		regulator-min-microvolt = <3300000>;
+		regulator-max-microvolt = <3300000>;
+		vin-supply = <&reg_vcc5v>;
+		regulator-always-on;
+	};
+
+	reg_vcc_core: regulator-core {
+		compatible = "regulator-fixed";
+		regulator-name = "vcc-core";
+		regulator-min-microvolt = <880000>;
+		regulator-max-microvolt = <880000>;
+		vin-supply = <&reg_vcc5v>;
+		regulator-always-on;
+	};
+};
+
+&cpu0 {
+	cpu-supply = <&reg_vcc_core>;
+};
+
+&cpu1 {
+	cpu-supply = <&reg_vcc_core>;
+};
+
+&rtc {
+	status = "okay";
+};
+
+&dcxo {
+	clock-frequency = <24000000>;
+};
+
+&wdt {
+	status = "okay";
+};
+
+&pio {
+	vcc-pb-supply = <&reg_3v3>;
+	vcc-pc-supply = <&reg_3v3>;
+	vcc-pd-supply = <&reg_3v3>;
+	vcc-pe-supply = <&reg_3v3>;
+	vcc-pf-supply = <&reg_3v3>;
+	vcc-pg-supply = <&reg_3v3>;
+
+	gpio-line-names =
+		/* PA */
+		"","","","","","","","",
+		"","","","","","","","",
+		"","","","","","","","",
+		"","","","","","","","",
+		/* PB */
+		"","","I2C0_SDA","I2C0_SCL","","","","",
+		"","","","","","","","",
+		"","","","","","","","",
+		"","","","","","","","",
+		/* PC */
+		"","","","","","","","",
+		"","","","","","","","",
+		"","","","","","","","",
+		"","","","","","","","",
+		/* PD */
+		"","UART2_TX","UART2_RX","","LED_1","LED_2","CONFIG_4","CONFIG_3",
+		"CONFIG_2","CONFIG_1","SPI_CS","SPI_CLK","SPI_MOSI","","","",
+		"EPD_DC","EPD_RESET","EPD_BUSY","","","","","",
+		"","","","","","","","",
+		/* PE */
+		"STM_RESET","POWER_OFF","PE2","PE3","PE4","PE5","PE6","PE7",
+		"PE8","PE9","PE10","PE11","PE12","PE13","","",
+		"","","","","","","","",
+		"","","","","","","","",
+		/* PF */
+		"","","","","","","","",
+		"","","","","","","","",
+		"","","","","","","","",
+		"","","","","","","","",
+		/* PG */
+		"","WIFI_EN","DEBUG_TX","DEBUG_RX","","","I2C2_SCL","I2C2_SDA",
+		"","","","","","","","",
+		"","","","","","","","",
+		"","","","","","","","";
+
+	uart4_pg_pins: uart4-pg-pins {
+		pins = "PG2", "PG3";
+		function = "uart4";
+	};
+
+	spi1_pd_pins: spi1-pd-pins {
+		pins = "PD10", "PD11", "PD12", "PD13";
+		function = "spi1";
+	};
+
+	i2c0_pb_pins: i2c0-pb-pins {
+		pins = "PB2", "PB3";
+		function = "i2c0";
+	};
+
+	i2c2_pg_pins: i2c2-pg-pins {
+		pins = "PG6", "PG7";
+		function = "i2c2";
+	};
+
+	uart0_pe_pins: uart0-pe-pins {
+		pins = "PE2", "PE3";
+		function = "uart0";
+	};
+
+	uart2_pd_pins: uart2-pd-pins {
+		pins = "PD1", "PD2";
+		function = "uart2";
+	};
+
+	// Expansion header pin definitions
+
+	i2c0_pe_pins: i2c0-pe-pins {
+		pins = "PE2", "PE3";
+		function = "i2c0";
+	};
+
+	// LEDC for driving Neopixels
+	ledc_pe_pins: ledc-pe-pins {
+		pins = "PE5";
+		function = "ledc";
+	};
+
+	// Motor driver inputs (driven via PWM)
+	pwm2_pe_pin: pwm2-pe-pin {
+		pins = "PE8";
+		function = "pwm2";
+	};
+
+	pwm3_pe_pin: pwm3-pe-pin {
+		pins = "PE9";
+		function = "pwm3";
+	};
+
+	pwm4_pe_pin: pwm4-pe-pin {
+		pins = "PE10";
+		function = "pwm4";
+	};
+
+	pwm5_pe_pin: pwm5-pe-pin {
+		pins = "PE13";
+		function = "pwm5";
+	};
+};
+
+/* shell */
+&uart4 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&uart4_pg_pins>;
+	status = "okay";
+};
+
+&mmc0 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&mmc0_pins>;
+	vmmc-supply = <&reg_3v3>;
+	disable-wp;
+	bus-width = <4>;
+	max-frequency = <50000000>;
+	non-removable;
+	broken-cd;
+	no-1-8-v;
+	status = "okay";
+};
+
+&gpadc {
+	status = "disabled";
+};
+
+&usb_otg {
+	dr_mode = "peripheral";
+	status = "okay";
+};
+
+&usbphy {
+	status = "okay";
+};
+
+&ehci1 {
+	status = "okay";
+};
+
+&ohci1 {
+	status = "okay";
+};
+
+&spi0 {
+	status = "disabled";
+};
+
+&spi1 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&spi1_pd_pins>;
+	status = "okay";
+
+	/* Generic spidev on chip-select 0  → /dev/spidev0.0 */
+	spidev0: spidev@0 {
+	  compatible = "menlo,m53cpld";
+	  reg = <0>;
+	  spi-max-frequency = <10000000>;
+	};
+};
+
+&mixer0 {
+	status = "disabled";
+};
+
+&tcon_top {
+	status = "disabled";
+};
+
+&tcon_lcd0 {
+	status = "disabled";
+};
+
+&crypto {
+	status = "okay";
+};
+
+// enable PWM channels on motor driver pins
+&pwm {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pwm2_pe_pin>, <&pwm3_pe_pin>, <&pwm4_pe_pin>, <&pwm5_pe_pin>;
+	status = "okay";
+};
+
+/*
+ * NeoPixels on the expansion board
+ *
+ * 6.18 added support for LEDC peripheral, but didn't add the device tree node.
+ * The LEDC peripheral device tree node was added in kernel version 7.0
+ */
+&{/soc} {
+	ledc: led-controller@2008000 {
+		compatible = "allwinner,sun20i-d1-ledc",
+			     "allwinner,sun50i-a100-ledc";
+		reg = <0x2008000 0x400>;
+		interrupts = <SOC_PERIPHERAL_IRQ(20) IRQ_TYPE_LEVEL_HIGH>;
+		clocks = <&ccu CLK_BUS_LEDC>, <&ccu CLK_LEDC>;
+		clock-names = "bus", "mod";
+		resets = <&ccu RST_BUS_LEDC>;
+		dmas = <&dma 42>;
+		dma-names = "tx";
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		pinctrl-names = "default";
+		pinctrl-0 = <&ledc_pe_pins>;
+		status = "okay";
+
+		multi-led@0 {
+			reg = <0x0>;
+			color = <LED_COLOR_ID_RGB>;
+			function = LED_FUNCTION_INDICATOR;
+			function-enumerator = <0>;
+		};
+
+		multi-led@1 {
+			reg = <0x1>;
+			color = <LED_COLOR_ID_RGB>;
+			function = LED_FUNCTION_INDICATOR;
+			function-enumerator = <1>;
+		};
+
+		multi-led@2 {
+			reg = <0x2>;
+			color = <LED_COLOR_ID_RGB>;
+			function = LED_FUNCTION_INDICATOR;
+			function-enumerator = <2>;
+		};
+
+		multi-led@3 {
+			reg = <0x3>;
+			color = <LED_COLOR_ID_RGB>;
+			function = LED_FUNCTION_INDICATOR;
+			function-enumerator = <3>;
+		};
+	};
+};
+
+&uart0 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&uart0_pe_pins>;
+	status = "disabled";
+};
+
+&uart2 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&uart2_pd_pins>;
+	status = "okay";
+};
+
+// NSK onboard sensors and expansion header both are on I2C0, so
+// we enable two sets of pins here
+&i2c0 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&i2c0_pb_pins>, <&i2c0_pe_pins>;
+	status = "okay";
+};
+
+&i2c2 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&i2c2_pg_pins>;
+	status = "okay";
+};
+

--- a/trellis.its
+++ b/trellis.its
@@ -36,6 +36,19 @@
             };
         };
 
+        fdt-nsk-balance-bot {
+            description = "NSK with balance bot expansion board device tree";
+            data = /incbin/("sun8i-t113s-nsk-balance-bot.dtb");
+            type = "flat_dt";
+            arch = "arm";
+            compression = "none";
+            load = <0x41800000>;
+
+            hash {
+                algo = "sha256";
+            };
+        };
+
         fdt-goatmire-badge {
             description = "Goatmire Badge device tree";
             data = /incbin/("sun8i-t113s-goatmire-badge.dtb");
@@ -57,6 +70,12 @@
             description = "Nerves Starter Kit";
             kernel = "kernel";
             fdt = "fdt-nerves-starter-kit";
+        };
+
+        nsk-balance-bot {
+            description = "NSK with balance bot expansion";
+            kernel = "kernel";
+            fdt = "fdt-nsk-balance-bot";
         };
 
         goatmire-badge {


### PR DESCRIPTION
Opening as a draft because two of these three changes have a trade-off worth discussing before anyone merges them.

## What this is

The Nerves Starter Kit's 14 pin GPIO header (J6) carries `PE2`, `PE3`, `PE5`, `PE8`, `PE9`, `PE10` and `PE13`. Almost nothing those pins can do is reachable from the stock device tree, so anything plugged into that header is limited to two GPIOs.

I've been bringing up the Beam Bots balance bot add-on, which uses all of them: two DRV8837 motor bridges on four PWM channels, a BMI323 IMU on I²C, four addressable LEDs on LEDC, and two GPIOs for the bridge sleep pins.

## The changes

**PWM** — a pinctrl group per channel, and `&pwm` enabled. This is the uncontroversial one: the kernel side is already here (the four PWM patches, `CONFIG_PWM_SUN8I=y`), the node was just left disabled. Gives the header `PWM2` through `PWM5` as `pwmchip0` channels 2–5.

**LEDC** — a node for `PE5`. The driver is in 6.18 and `CONFIG_LEDS_SUN50I_A100=y` is already set, but the device tree node landed upstream *after* 6.18, so there's nothing to reference. I've declared it in the board DTS via `&{/soc}`, since the `soc` node has no label.

*Question for you:* would you rather carry this as a fifth `linux/` patch adding the node to `sunxi-d1s-t113.dtsi`, matching how PWM is handled, and drop it from the board file when the kernel catches up? I went with the board DTS because a patch only applies at extract time, so iterating on it costs a full kernel rebuild — but the patch is the tidier place for it.

**I²C** — `&i2c0` muxed onto `PE2`/`PE3` in addition to `PB2`/`PB3`.

This is the one I'd most like a second opinion on. Those header pins offer `i2c0` and nothing else, and `i2c0` already carries the board's own LIS3DH, HTS221 and ATECC608B. Rather than choose between the onboard sensors and anything on the header, I've muxed the controller onto both pin pairs so they form one bus — it's open drain, the addresses differ, and it works.

The cost is that `PE2`/`PE3` stop being available as `uart0` or as GPIO. They're currently named `"PE2"`/`"PE3"` in `gpio-line-names`, which rather implies GPIO is the expected use, so this takes something away from anyone using the header differently. If you'd rather that not be the default, I'm happy to split it out, or drop it and carry it downstream.

## Verified

On a Nerves Starter Kit with the add-on fitted:

- `pwmchip0` with 8 channels, four of them driving two DRV8837 bridges — both motors turn, both directions.
- BMI323 answering at `0x68` on `i2c-0`, alongside the board's own `0x19`, `0x5F` and `0x60`. Orientation working through a Madgwick filter.
- Four LEDs under `/sys/class/leds/rgb:indicator-{0..3}`, correct colours.

The base board's own sensors are unaffected by sharing the bus, which was the main thing I wanted to be sure of.

Happy to split this into separate PRs if the I²C part needs its own conversation.