### PR TITLE
Remove rootfstype to allow booting both erofs and squashfs

### DIFF
--- a/uboot/uboot.env
+++ b/uboot/uboot.env
@@ -96,8 +96,8 @@ nerves_init=\
 devtype=mmc
 devnum=0
 console_args=console=ttyS4,115200 quiet
-rootfs_a_args=root=/dev/mmcblk0p2 rootfstype=squashfs rootwait
-rootfs_b_args=root=/dev/mmcblk0p3 rootfstype=squashfs rootwait
+rootfs_a_args=root=/dev/mmcblk0p2 rootwait
+rootfs_b_args=root=/dev/mmcblk0p3 rootwait
 fit_config=nerves-starter-kit
 
 fit_a_offset=0x2800


### PR DESCRIPTION
The drawback is that Linux might waste some time checking if the rootfs
is EXT4 first, but it doesn't look like that has a measurable effect on
boot time.
